### PR TITLE
[86bxyzh3m] Reset associated subcontrol owner and operator when user is removed from a project

### DIFF
--- a/app/repository/project.py
+++ b/app/repository/project.py
@@ -58,7 +58,7 @@ class ProjectRepository:
     @staticmethod
     def update_project_notes(project_id: int, notes: str):
         try:
-            Project.query.filter_by(id=project_id).update({'notes': notes})
+            Project.query.filter_by(id=project_id).update({Project.notes: notes})
             db.session.commit()
         except Exception as e:
             db.session.rollback()

--- a/app/repository/project_member.py
+++ b/app/repository/project_member.py
@@ -64,7 +64,7 @@ class ProjectMemberRepository:
             ProjectMember.query.filter_by(
                 project_id=project_id,
                 user_id=user_id
-            ).update({'access_level': access_level})
+            ).update({ProjectMember.access_level: access_level})
             db.session.commit()
         except Exception as e:
             db.session.rollback()

--- a/app/service/project_member.py
+++ b/app/service/project_member.py
@@ -51,3 +51,4 @@ class ProjectMemberService:
     @staticmethod
     def remove_project_member(project_id: int, user_id: int) -> None:
         ProjectMemberRepository.delete_project_member(project_id, user_id)
+        ProjectSubControlRepository.reset_subcontrol_ownership(project_id, user_id)


### PR DESCRIPTION
### Summary of changes

- When removing user from a project, all associated subcontrols where this user is owner or operator are set to `NULL`